### PR TITLE
Fixes for ovms

### DIFF
--- a/ref-apps/lva-edge-iot-central-gateway/README.md
+++ b/ref-apps/lva-edge-iot-central-gateway/README.md
@@ -18,13 +18,13 @@ git clone https://github.com/Azure/live-video-analytics
 ```
 Open the cloned **live-video-analytics** repository and cd into the *ref-apps/lva-edge-iot-central-gateway* folder with VS Code.
 
-## Modify Inference Endpoint for Custom Inference Service
-In order to bring up your custom inference service, you need to modify the inference URL in *objectGraphTopology.json*. Please follow below instructions to update the inference URL.
-1. In VS Code, open *setup/objectGraphTopology.json* file.
-2. Edit the `inferencingUrl` section to update the default value of `inference URL`(Line no.34). Below are the list of available inference endpoints for LVA.
+## Add Inference Endpoint for Custom Inference Service
+In order to bring up your own custom inference service, you need to include the inference URL in *objectGraphInstance.json*. Please follow below instructions to add value of inference URL.
+1. In VS Code, open *setup/objectGraphInstance.json* file.
+2. Edit the `inferencingUrl` parameter section to add value of `inference URL`(Line no.26). Below are the list of available inference endpoint values for LVA.
 
 **OpenVINO™ Model Server**
-- Vehicle Detection (Default): http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection 
+- Vehicle Detection: http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection 
 - Person Vehicle Bike Detection: http://OpenVINOModelServerEdgeAIExtensionModule:4000/personVehicleBikeDetection 
 - Face Detection: http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection   
 

--- a/ref-apps/lva-edge-iot-central-gateway/README.md
+++ b/ref-apps/lva-edge-iot-central-gateway/README.md
@@ -18,6 +18,20 @@ git clone https://github.com/Azure/live-video-analytics
 ```
 Open the cloned **live-video-analytics** repository and cd into the *ref-apps/lva-edge-iot-central-gateway* folder with VS Code.
 
+## Modify Inference Endpoint for Custom Inference Service
+In order to bring up your custom inference service, you need to modify the inference URL in *objectGraphTopology.json*. Please follow below instructions to update the inference URL.
+1. In VS Code, open *setup/objectGraphTopology.json* file.
+2. Edit the `inferencingUrl` section to update the default value of `inference URL`(Line no.34). Below are the list of available inference endpoints for LVA.
+
+**OpenVINO™ Model Server**
+- Vehicle Detection (Default): http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection 
+- Person Vehicle Bike Detection: http://OpenVINOModelServerEdgeAIExtensionModule:4000/personVehicleBikeDetection 
+- Face Detection: http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection   
+
+**YOLOv3**
+- Object Detection: http://lvaYolov3/score
+
+
 ## Edit the deployment.amd64.json file
 1. If you haven't already done so, create a folder called *storage* in the project folder. This folder is ignored by Git so as to prevent you accidentally checking in any confidential information.
 1. Copy the file setup/deployment.amd64.json* and save it in the *storage* folder.

--- a/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphInstance.json
+++ b/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphInstance.json
@@ -22,7 +22,7 @@
                 "value": ""
             },
             {
-                "name": "inferencing Url",
+                "name": "inferencingUrl",
                 "value": ""
             }
         ]

--- a/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphInstance.json
+++ b/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphInstance.json
@@ -20,6 +20,10 @@
             {
                 "name": "assetName",
                 "value": ""
+            },
+            {
+                "name": "inferencing Url",
+                "value": ""
             }
         ]
     }

--- a/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphTopology.json
+++ b/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphTopology.json
@@ -30,8 +30,7 @@
             {
                 "name": "inferencingUrl",
                 "type": "String",
-                "description": "inferencing Url",
-                "default": "http://lvaYolov3/score"
+                "description": "inferencing Url"
             },
             {
                 "name": "inferencingUserName",

--- a/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphTopology.json
+++ b/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphTopology.json
@@ -5,11 +5,6 @@
         "description": "Event-based video recording to Assets based on motion events, and using HTTP Extension to send images to an external inference engine",
         "parameters": [
             {
-                "name": "rtspUrl",
-                "type": "String",
-                "description": "rtsp Url"
-            },
-            {
                 "name": "rtspAuthUsername",
                 "type": "String",
                 "description": "rtsp source user name.",
@@ -22,6 +17,11 @@
                 "default": "password"
             },
             {
+                "name": "rtspUrl",
+                "type": "String",
+                "description": "rtsp Url"
+            },
+            {
                 "name": "assetName",
                 "type": "String",
                 "description": "name of the AMS CVR asset",
@@ -31,7 +31,7 @@
                 "name": "inferencingUrl",
                 "type": "String",
                 "description": "inferencing Url",
-                "default": "http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection"
+                "default": "http://lvaYolov3/score"
             },
             {
                 "name": "inferencingUserName",
@@ -46,6 +46,24 @@
                 "default": "password"
             },
             {
+                "name": "imageScaleMode",
+                "type": "String",
+                "description": "image scaling mode",
+                "default": "preserveAspectRatio"
+            },
+            {
+                "name": "frameWidth",
+                "type": "String",
+                "description": "Width of the video frame to be received from LVA.",
+                "default": "416"
+            },
+            {
+                "name": "frameHeight",
+                "type": "String",
+                "description": "Height of the video frame to be received from LVA.",
+                "default": "416"
+            },
+            {
                 "name": "hubSinkOutputName",
                 "type": "String",
                 "description": "hub sink output name",
@@ -56,6 +74,7 @@
             {
                 "@type": "#Microsoft.Media.MediaGraphRtspSource",
                 "name": "rtspSource",
+                "transport": "tcp",
                 "endpoint": {
                     "@type": "#Microsoft.Media.MediaGraphUnsecuredEndpoint",
                     "url": "${rtspUrl}",
@@ -82,17 +101,17 @@
                 },
                 "image": {
                     "scale": {
-                        "mode": "preserveAspectRatio",
-                        "width": "416",
-                        "height": "416"
+                        "mode": "${imageScaleMode}",
+                        "width": "${frameWidth}",
+                        "height": "${frameHeight}"
                     },
                     "format": {
                         "@type": "#Microsoft.Media.MediaGraphImageFormatBmp"
-                    },
-                    "samplingOptions": {
-                        "skipSamplesWithoutAnnotation": "false",
-                        "maximumSamplesPerSecond": "20"
                     }
+                },
+                "samplingOptions": {
+                    "skipSamplesWithoutAnnotation": "false",
+                    "maximumSamplesPerSecond": "20"
                 },
                 "inputs": [
                     {

--- a/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphTopology.json
+++ b/ref-apps/lva-edge-iot-central-gateway/setup/objectGraphTopology.json
@@ -31,7 +31,7 @@
                 "name": "inferencingUrl",
                 "type": "String",
                 "description": "inferencing Url",
-                "default": "http://lvaYolov3/score"
+                "default": "http://OpenVINOModelServerEdgeAIExtensionModule:4000/vehicleDetection"
             },
             {
                 "name": "inferencingUserName",


### PR DESCRIPTION
1. Updated the inference URL in objectGraphTopology.json to make OpenVINO as default inference endpoint.
2. Updated the README with instructions to modify inference endpoint .